### PR TITLE
Fix: Escape Liquid-like macro syntax to prevent GitHub Pages build fa…

### DIFF
--- a/script.js
+++ b/script.js
@@ -154,7 +154,7 @@ function generateMacro(text) {
   let result = [];
 
   if (consoleCheckbox.checked) {
-    result.push('{{oem_3}{PAUSE:200}}'); // Add tilde and a 200ms pause for Ark console
+    result.push('{' + '{oem_3}{PAUSE:200}' + '}'); // Add tilde and a 200ms pause for Ark console // Prevent Jekyll Liquid parsing by avoiding literal {{}} 
   }
 
   result.push('{');


### PR DESCRIPTION
…ilure

- Refactored the Ark console macro line to avoid using literal double curly braces ({{oem_3}})
- Replaced '{{oem_3}{PAUSE:200}}' with '{' + '{oem_3}{PAUSE:200}' + '}' to avoid triggering Liquid syntax parsing
- Added inline comment explaining the change for future maintenance
- Fixes build error on GitHub Pages caused by unescaped Liquid-like syntax